### PR TITLE
Remove entries from CountiesTableSeeder

### DIFF
--- a/database/seeds/CountiesTableSeeder.php
+++ b/database/seeds/CountiesTableSeeder.php
@@ -24,16 +24,6 @@ class CountiesTableSeeder extends Seeder
                 ]);
             }
         }
-        
-        County::create([
-                'name' => 'Anti corruption',
-                'code' =>  'AI'
-        ]);
-        
-        County::create([
-                'name' => 'Ministry',
-                'code' =>  'MI'
-        ]);
     }
 
     private function getCounties()


### PR DESCRIPTION
We remove "Anticorruption" and "Ministry", because
they don't belong in this table.

Fixes #18.